### PR TITLE
Added required packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install dependencies
 
 ```bash
 sudo apt-get update
-sudo apt-get install git-core build-essential libssl-dev libncurses5-dev unzip subversion gawk python
+sudo apt-get install git-core build-essential libssl-dev libncurses5-dev unzip subversion gawk python python-passlib
 ```
 
 


### PR DESCRIPTION
python and python-passlib are required to run build.sh on a minimal debian jessie 